### PR TITLE
Upgrading to PHPUnit 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Disclaimer: Doing this in PHP is not as easy as in programming languages which s
 Using static method calls:
 
 ``` php
-class VCRTest extends \PHPUnit_Framework_TestCase
+class VCRTest extends TestCase
 {
     public function testShouldInterceptStreamWrapper()
     {
@@ -68,7 +68,7 @@ class VCRTest extends \PHPUnit_Framework_TestCase
 You can use annotations in PHPUnit by using [phpunit-testlistener-vcr](https://github.com/php-vcr/phpunit-testlistener-vcr):
 
 ``` php
-class VCRTest extends \PHPUnit_Framework_TestCase
+class VCRTest extends TestCase
 {
     /**
      * @vcr unittest_annotation_test

--- a/composer.json
+++ b/composer.json
@@ -26,10 +26,8 @@
     },
 
     "require-dev": {
-        "phpunit/phpunit": "^4.8|^5.0",
-        "sebastian/comparator": "^1.2.4",
+        "phpunit/phpunit": "^7.4.3",
         "mikey179/vfsStream": "^1.2",
-        "lapistano/proxy-object": "dev-master#d7184a479f502d5a0f96d0bae73566dbb498da8f",
         "phpstan/phpstan": "^0.10.5"
     },
 

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "a02ecf31e56df3052f290dc8b81b7486",
+    "content-hash": "1354b1a85494d7a07315f638d1921a27",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -391,52 +391,6 @@
                 "versions"
             ],
             "time": "2018-06-13T13:22:40+00:00"
-        },
-        {
-            "name": "lapistano/proxy-object",
-            "version": "dev-master",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/lapistano/proxy-object.git",
-                "reference": "d7184a479f502d5a0f96d0bae73566dbb498da8f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/lapistano/proxy-object/zipball/d7184a479f502d5a0f96d0bae73566dbb498da8f",
-                "reference": "d7184a479f502d5a0f96d0bae73566dbb498da8f",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.2"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "@stable"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "lapistano\\ProxyObject": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Apache 2.0"
-            ],
-            "authors": [
-                {
-                    "name": "Bastian Feder",
-                    "email": "lapis@bastian-feder.de",
-                    "homepage": "http://blog.bastian-feder.de"
-                }
-            ],
-            "description": "A library that makes it much easier to generate a proxy of your system under test (SUT)",
-            "homepage": "http://www.github.com/lapistano/proxy-object",
-            "keywords": [
-                "phpunit",
-                "proxy-object",
-                "testing"
-            ],
-            "time": "2015-06-24T09:27:33+00:00"
         },
         {
             "name": "mikey179/vfsStream",
@@ -1110,6 +1064,108 @@
             "time": "2018-02-05T13:05:30+00:00"
         },
         {
+            "name": "phar-io/manifest",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
+                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-phar": "*",
+                "phar-io/version": "^2.0",
+                "php": "^5.6 || ^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "time": "2018-07-08T19:23:20+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/45a2ec53a73c70ce41d55cedef9063630abaf1b6",
+                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "time": "2018-07-08T19:19:57+00:00"
+        },
+        {
             "name": "phpdocumentor/reflection-common",
             "version": "1.0.1",
             "source": {
@@ -1441,40 +1497,40 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "4.0.8",
+            "version": "6.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "ef7b2f56815df854e66ceaee8ebe9393ae36a40d"
+                "reference": "4d3ae9b21a7d7e440bd0cf65565533117976859f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/ef7b2f56815df854e66ceaee8ebe9393ae36a40d",
-                "reference": "ef7b2f56815df854e66ceaee8ebe9393ae36a40d",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/4d3ae9b21a7d7e440bd0cf65565533117976859f",
+                "reference": "4d3ae9b21a7d7e440bd0cf65565533117976859f",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-xmlwriter": "*",
-                "php": "^5.6 || ^7.0",
-                "phpunit/php-file-iterator": "^1.3",
-                "phpunit/php-text-template": "^1.2",
-                "phpunit/php-token-stream": "^1.4.2 || ^2.0",
-                "sebastian/code-unit-reverse-lookup": "^1.0",
-                "sebastian/environment": "^1.3.2 || ^2.0",
-                "sebastian/version": "^1.0 || ^2.0"
+                "php": "^7.1",
+                "phpunit/php-file-iterator": "^2.0",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-token-stream": "^3.0",
+                "sebastian/code-unit-reverse-lookup": "^1.0.1",
+                "sebastian/environment": "^3.1 || ^4.0",
+                "sebastian/version": "^2.0.1",
+                "theseer/tokenizer": "^1.1"
             },
             "require-dev": {
-                "ext-xdebug": "^2.1.4",
-                "phpunit/phpunit": "^5.7"
+                "phpunit/phpunit": "^7.0"
             },
             "suggest": {
-                "ext-xdebug": "^2.5.1"
+                "ext-xdebug": "^2.6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0.x-dev"
+                    "dev-master": "6.1-dev"
                 }
             },
             "autoload": {
@@ -1489,7 +1545,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -1500,29 +1556,32 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-04-02T07:44:40+00:00"
+            "time": "2018-10-23T05:59:32+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.5",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4"
+                "reference": "050bedf145a257b1ff02746c31894800e5122946"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/730b01bc3e867237eaac355e06a36b85dd93a8b4",
-                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/050bedf145a257b1ff02746c31894800e5122946",
+                "reference": "050bedf145a257b1ff02746c31894800e5122946",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -1537,7 +1596,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -1547,7 +1606,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2017-11-27T13:52:08+00:00"
+            "time": "2018-09-13T20:33:42+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -1592,28 +1651,28 @@
         },
         {
             "name": "phpunit/php-timer",
-            "version": "1.0.9",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f"
+                "reference": "8b8454ea6958c3dee38453d3bd571e023108c91f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
-                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/8b8454ea6958c3dee38453d3bd571e023108c91f",
+                "reference": "8b8454ea6958c3dee38453d3bd571e023108c91f",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -1628,7 +1687,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -1637,33 +1696,33 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2017-02-26T11:10:40+00:00"
+            "time": "2018-02-01T13:07:23+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "2.0.2",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "791198a2c6254db10131eecfe8c06670700904db"
+                "reference": "21ad88bbba7c3d93530d93994e0a33cd45f02ace"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/791198a2c6254db10131eecfe8c06670700904db",
-                "reference": "791198a2c6254db10131eecfe8c06670700904db",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/21ad88bbba7c3d93530d93994e0a33cd45f02ace",
+                "reference": "21ad88bbba7c3d93530d93994e0a33cd45f02ace",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": "^7.0"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.2.4"
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -1686,55 +1745,57 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2017-11-27T05:48:46+00:00"
+            "time": "2018-02-01T13:16:43+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "5.7.27",
+            "version": "7.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "b7803aeca3ccb99ad0a506fa80b64cd6a56bbc0c"
+                "reference": "c151651fb6ed264038d486ea262e243af72e5e64"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b7803aeca3ccb99ad0a506fa80b64cd6a56bbc0c",
-                "reference": "b7803aeca3ccb99ad0a506fa80b64cd6a56bbc0c",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c151651fb6ed264038d486ea262e243af72e5e64",
+                "reference": "c151651fb6ed264038d486ea262e243af72e5e64",
                 "shasum": ""
             },
             "require": {
+                "doctrine/instantiator": "^1.1",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
-                "myclabs/deep-copy": "~1.3",
-                "php": "^5.6 || ^7.0",
-                "phpspec/prophecy": "^1.6.2",
-                "phpunit/php-code-coverage": "^4.0.4",
-                "phpunit/php-file-iterator": "~1.4",
-                "phpunit/php-text-template": "~1.2",
-                "phpunit/php-timer": "^1.0.6",
-                "phpunit/phpunit-mock-objects": "^3.2",
-                "sebastian/comparator": "^1.2.4",
-                "sebastian/diff": "^1.4.3",
-                "sebastian/environment": "^1.3.4 || ^2.0",
-                "sebastian/exporter": "~2.0",
-                "sebastian/global-state": "^1.1",
-                "sebastian/object-enumerator": "~2.0",
-                "sebastian/resource-operations": "~1.0",
-                "sebastian/version": "^1.0.6|^2.0.1",
-                "symfony/yaml": "~2.1|~3.0|~4.0"
+                "myclabs/deep-copy": "^1.7",
+                "phar-io/manifest": "^1.0.2",
+                "phar-io/version": "^2.0",
+                "php": "^7.1",
+                "phpspec/prophecy": "^1.7",
+                "phpunit/php-code-coverage": "^6.0.7",
+                "phpunit/php-file-iterator": "^2.0.1",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-timer": "^2.0",
+                "sebastian/comparator": "^3.0",
+                "sebastian/diff": "^3.0",
+                "sebastian/environment": "^3.1 || ^4.0",
+                "sebastian/exporter": "^3.1",
+                "sebastian/global-state": "^2.0",
+                "sebastian/object-enumerator": "^3.0.3",
+                "sebastian/resource-operations": "^2.0",
+                "sebastian/version": "^2.0.1"
             },
             "conflict": {
-                "phpdocumentor/reflection-docblock": "3.0.2"
+                "phpunit/phpunit-mock-objects": "*"
             },
             "require-dev": {
                 "ext-pdo": "*"
             },
             "suggest": {
+                "ext-soap": "*",
                 "ext-xdebug": "*",
-                "phpunit/php-invoker": "~1.1"
+                "phpunit/php-invoker": "^2.0"
             },
             "bin": [
                 "phpunit"
@@ -1742,7 +1803,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.7.x-dev"
+                    "dev-master": "7.4-dev"
                 }
             },
             "autoload": {
@@ -1768,66 +1829,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-02-01T05:50:59+00:00"
-        },
-        {
-            "name": "phpunit/phpunit-mock-objects",
-            "version": "3.4.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "a23b761686d50a560cc56233b9ecf49597cc9118"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/a23b761686d50a560cc56233b9ecf49597cc9118",
-                "reference": "a23b761686d50a560cc56233b9ecf49597cc9118",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/instantiator": "^1.0.2",
-                "php": "^5.6 || ^7.0",
-                "phpunit/php-text-template": "^1.2",
-                "sebastian/exporter": "^1.2 || ^2.0"
-            },
-            "conflict": {
-                "phpunit/phpunit": "<5.4.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^5.4"
-            },
-            "suggest": {
-                "ext-soap": "*"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.2.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Mock Object library for PHPUnit",
-            "homepage": "https://github.com/sebastianbergmann/phpunit-mock-objects/",
-            "keywords": [
-                "mock",
-                "xunit"
-            ],
-            "time": "2017-06-30T09:13:00+00:00"
+            "time": "2018-10-23T05:57:41+00:00"
         },
         {
             "name": "psr/log",
@@ -1923,30 +1925,30 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "1.2.4",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be"
+                "reference": "5de4fc177adf9bce8df98d8d141a7559d7ccf6da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
-                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/5de4fc177adf9bce8df98d8d141a7559d7ccf6da",
+                "reference": "5de4fc177adf9bce8df98d8d141a7559d7ccf6da",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "sebastian/diff": "~1.2",
-                "sebastian/exporter": "~1.2 || ~2.0"
+                "php": "^7.1",
+                "sebastian/diff": "^3.0",
+                "sebastian/exporter": "^3.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2.x-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -1977,38 +1979,39 @@
                 }
             ],
             "description": "Provides the functionality to compare PHP values for equality",
-            "homepage": "http://www.github.com/sebastianbergmann/comparator",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
             "keywords": [
                 "comparator",
                 "compare",
                 "equality"
             ],
-            "time": "2017-01-29T09:50:25+00:00"
+            "time": "2018-07-12T15:12:46+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "1.4.3",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4"
+                "reference": "366541b989927187c4ca70490a35615d3fef2dce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/7f066a26a962dbe58ddea9f72a4e82874a3975a4",
-                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/366541b989927187c4ca70490a35615d3fef2dce",
+                "reference": "366541b989927187c4ca70490a35615d3fef2dce",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
+                "phpunit/phpunit": "^7.0",
+                "symfony/process": "^2 || ^3.3 || ^4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -2033,34 +2036,37 @@
             "description": "Diff implementation",
             "homepage": "https://github.com/sebastianbergmann/diff",
             "keywords": [
-                "diff"
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
             ],
-            "time": "2017-05-22T07:24:03+00:00"
+            "time": "2018-06-10T07:54:39+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "2.0.0",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac"
+                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
-                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
+                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.0"
+                "phpunit/phpunit": "^6.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "3.1.x-dev"
                 }
             },
             "autoload": {
@@ -2085,34 +2091,34 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-11-26T07:53:53+00:00"
+            "time": "2017-07-01T08:51:00+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "2.0.0",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4"
+                "reference": "234199f4528de6d12aaa58b612e98f7d36adb937"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4",
-                "reference": "ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/234199f4528de6d12aaa58b612e98f7d36adb937",
+                "reference": "234199f4528de6d12aaa58b612e98f7d36adb937",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "sebastian/recursion-context": "~2.0"
+                "php": "^7.0",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
                 "ext-mbstring": "*",
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "3.1.x-dev"
                 }
             },
             "autoload": {
@@ -2152,27 +2158,27 @@
                 "export",
                 "exporter"
             ],
-            "time": "2016-11-19T08:54:04+00:00"
+            "time": "2017-04-03T13:19:02+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "1.1.1",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4"
+                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bc37d50fea7d017d3d340f230811c9f1d7280af4",
-                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
+                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.2"
+                "phpunit/phpunit": "^6.0"
             },
             "suggest": {
                 "ext-uopz": "*"
@@ -2180,7 +2186,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -2203,33 +2209,34 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-10-12T03:26:01+00:00"
+            "time": "2017-04-27T15:39:26+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "2.0.1",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "1311872ac850040a79c3c058bea3e22d0f09cbb7"
+                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/1311872ac850040a79c3c058bea3e22d0f09cbb7",
-                "reference": "1311872ac850040a79c3c058bea3e22d0f09cbb7",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/7cfd9e65d11ffb5af41198476395774d4c8a84c5",
+                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6",
-                "sebastian/recursion-context": "~2.0"
+                "php": "^7.0",
+                "sebastian/object-reflector": "^1.1.1",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~5"
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -2249,32 +2256,77 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "time": "2017-02-18T15:18:39+00:00"
+            "time": "2017-08-03T12:35:26+00:00"
         },
         {
-            "name": "sebastian/recursion-context",
-            "version": "2.0.0",
+            "name": "sebastian/object-reflector",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "2c3ba150cbec723aa057506e73a8d33bdb286c9a"
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "773f97c67f28de00d397be301821b06708fca0be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/2c3ba150cbec723aa057506e73a8d33bdb286c9a",
-                "reference": "2c3ba150cbec723aa057506e73a8d33bdb286c9a",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/773f97c67f28de00d397be301821b06708fca0be",
+                "reference": "773f97c67f28de00d397be301821b06708fca0be",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "time": "2017-03-29T09:07:27+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -2302,29 +2354,29 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2016-11-19T07:33:16+00:00"
+            "time": "2017-03-03T06:23:57+00:00"
         },
         {
             "name": "sebastian/resource-operations",
-            "version": "1.0.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52"
+                "reference": "4d7a795d35b889bf80a0cc04e08d77cedfa917a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
-                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/4d7a795d35b889bf80a0cc04e08d77cedfa917a9",
+                "reference": "4d7a795d35b889bf80a0cc04e08d77cedfa917a9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6.0"
+                "php": "^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -2344,7 +2396,7 @@
             ],
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "time": "2015-07-28T20:34:47+00:00"
+            "time": "2018-10-04T04:07:39+00:00"
         },
         {
             "name": "sebastian/version",
@@ -2566,6 +2618,46 @@
             "time": "2018-08-06T14:22:27+00:00"
         },
         {
+            "name": "theseer/tokenizer",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "cb2f008f3f05af2893a87208fe6a6c4985483f8b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/cb2f008f3f05af2893a87208fe6a6c4985483f8b",
+                "reference": "cb2f008f3f05af2893a87208fe6a6c4985483f8b",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "time": "2017-04-07T12:08:54+00:00"
+        },
+        {
             "name": "webmozart/assert",
             "version": "1.3.0",
             "source": {
@@ -2618,9 +2710,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "lapistano/proxy-object": 20
-    },
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/tests/VCR/CassetteTest.php
+++ b/tests/VCR/CassetteTest.php
@@ -3,11 +3,12 @@
 namespace VCR;
 
 use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test integration of PHPVCR with PHPUnit.
  */
-class CassetteTest extends \PHPUnit_Framework_TestCase
+class CassetteTest extends TestCase
 {
 
     /**
@@ -23,7 +24,7 @@ class CassetteTest extends \PHPUnit_Framework_TestCase
 
     public function testInvalidCassetteName()
     {
-        $this->setExpectedException('\VCR\VCRException', 'Cassette name must be a string, array given.');
+        $this->expectException(VCRException::class, 'Cassette name must be a string, array given.');
         new Cassette(array(), new Configuration(), new Storage\Yaml(vfsStream::url('test/'), 'json_test'));
     }
 

--- a/tests/VCR/CodeTransform/AbstractCodeTransformTest.php
+++ b/tests/VCR/CodeTransform/AbstractCodeTransformTest.php
@@ -2,7 +2,9 @@
 
 namespace VCR\CodeTransform;
 
-class AbstractCodeTransformTest extends \PHPUnit_framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class AbstractCodeTransformTest extends TestCase
 {
     protected function getFilter(array $methods = array())
     {

--- a/tests/VCR/CodeTransform/CurlCodeTransformTest.php
+++ b/tests/VCR/CodeTransform/CurlCodeTransformTest.php
@@ -3,20 +3,24 @@
 namespace VCR\CodeTransform;
 
 use lapistano\ProxyObject\ProxyBuilder;
+use PHPUnit\Framework\TestCase;
 
-class CurlCodeTransformTest extends \PHPUnit_Framework_TestCase
+class CurlCodeTransformTest extends TestCase
 {
     /**
      * @dataProvider codeSnippetProvider
      */
     public function testTransformCode($expected, $code)
     {
-        $proxy = new ProxyBuilder('\VCR\CodeTransform\CurlCodeTransform');
-        $filter = $proxy
-            ->setMethods(array('transformCode'))
-            ->getProxy();
+        $codeTransform = new class extends CurlCodeTransform {
+            // A proxy to access the protected transformCode method.
+            public function publicTransformCode(string $code): string
+            {
+                return $this->transformCode($code);
+            }
+        };
 
-        $this->assertEquals($expected, $filter->transformCode($code));
+        $this->assertEquals($expected, $codeTransform->publicTransformCode($code));
     }
 
     public function codeSnippetProvider()

--- a/tests/VCR/CodeTransform/SoapCodeTransformTest.php
+++ b/tests/VCR/CodeTransform/SoapCodeTransformTest.php
@@ -3,20 +3,24 @@
 namespace VCR\CodeTransform;
 
 use lapistano\ProxyObject\ProxyBuilder;
+use PHPUnit\Framework\TestCase;
 
-class SoapCodeTransformTest extends \PHPUnit_Framework_TestCase
+class SoapCodeTransformTest extends TestCase
 {
     /**
      * @dataProvider codeSnippetProvider
      */
     public function testTransformCode($expected, $code)
     {
-        $proxy = new ProxyBuilder('\VCR\CodeTransform\SoapCodeTransform');
-        $filter = $proxy
-            ->setMethods(array('transformCode'))
-            ->getProxy();
+        $codeTransform = new class extends SoapCodeTransform {
+            // A proxy to access the protected transformCode method.
+            public function publicTransformCode(string $code): string
+            {
+                return $this->transformCode($code);
+            }
+        };
 
-        $this->assertEquals($expected, $filter->transformCode($code));
+        $this->assertEquals($expected, $codeTransform->publicTransformCode($code));
     }
 
     public function codeSnippetProvider()

--- a/tests/VCR/ConfigurationTest.php
+++ b/tests/VCR/ConfigurationTest.php
@@ -2,10 +2,12 @@
 
 namespace VCR;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  *
  */
-class ConfigurationTest extends \PHPUnit_Framework_TestCase
+class ConfigurationTest extends TestCase
 {
     /**
      * @var Configuration
@@ -19,8 +21,8 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
 
     public function testSetCassettePathThrowsErrorOnInvalidPath()
     {
-        $this->setExpectedException(
-            'VCR\VCRException',
+        $this->expectException(
+            VCRException::class,
             "Cassette path 'invalid_path' is not a directory. Please either "
             . 'create it or set a different cassette path using '
             . "\\VCR\\VCR::configure()->setCassettePath('directory')."
@@ -64,7 +66,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
 
     public function testEnableLibraryHooksFailsWithWrongHookName()
     {
-        $this->setExpectedException('InvalidArgumentException', "Library hooks don't exist: non_existing");
+        $this->expectException('InvalidArgumentException', "Library hooks don't exist: non_existing");
         $this->config->enableLibraryHooks(array('non_existing'));
     }
 
@@ -82,13 +84,13 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
 
     public function testEnableRequestMatchersFailsWithNoExistingName()
     {
-        $this->setExpectedException('InvalidArgumentException', "Request matchers don't exist: wrong, name");
+        $this->expectException('InvalidArgumentException', "Request matchers don't exist: wrong, name");
         $this->config->enableRequestMatchers(array('wrong', 'name'));
     }
 
     public function testAddRequestMatcherFailsWithNoName()
     {
-        $this->setExpectedException('VCR\VCRException', "A request matchers name must be at least one character long. Found ''");
+        $this->expectException('VCR\VCRException', "A request matchers name must be at least one character long. Found ''");
         $expected = function ($first, $second) {
             return true;
         };
@@ -97,7 +99,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
 
     public function testAddRequestMatcherFailsWithWrongCallback()
     {
-        $this->setExpectedException('VCR\VCRException', "Request matcher 'example' is not callable.");
+        $this->expectException('VCR\VCRException', "Request matcher 'example' is not callable.");
         $this->config->addRequestMatcher('example', array());
     }
 
@@ -129,7 +131,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
 
     public function testSetStorageInvalidName()
     {
-        $this->setExpectedException('VCR\VCRException', "Storage 'Does not exist' not available.");
+        $this->expectException('VCR\VCRException', "Storage 'Does not exist' not available.");
         $this->config->setStorage('Does not exist');
     }
 
@@ -161,7 +163,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
 
     public function testSetModeInvalidName()
     {
-        $this->setExpectedException('VCR\VCRException', "Mode 'invalid' does not exist.");
+        $this->expectException('VCR\VCRException', "Mode 'invalid' does not exist.");
         $this->config->setMode('invalid');
     }
 }

--- a/tests/VCR/Event/AfterHttpRequestEventTest.php
+++ b/tests/VCR/Event/AfterHttpRequestEventTest.php
@@ -2,10 +2,11 @@
 
 namespace VCR\Event;
 
+use PHPUnit\Framework\TestCase;
 use VCR\Request;
 use VCR\Response;
 
-class AfterHttpRequestEventTest extends \PHPUnit_Framework_TestCase
+class AfterHttpRequestEventTest extends TestCase
 {
     /**
      * @var AfterHttpRequestEvent

--- a/tests/VCR/Event/AfterPlaybackEventTest.php
+++ b/tests/VCR/Event/AfterPlaybackEventTest.php
@@ -2,13 +2,14 @@
 
 namespace VCR\Event;
 
+use PHPUnit\Framework\TestCase;
 use VCR\Request;
 use VCR\Cassette;
 use VCR\Configuration;
 use VCR\Storage;
 use VCR\Response;
 
-class AfterPlaybackEventTest extends \PHPUnit_Framework_TestCase
+class AfterPlaybackEventTest extends TestCase
 {
     /**
      * @var AfterPlaybackEvent

--- a/tests/VCR/Event/BeforeHttpRequestEventTest.php
+++ b/tests/VCR/Event/BeforeHttpRequestEventTest.php
@@ -2,9 +2,10 @@
 
 namespace VCR\Event;
 
+use PHPUnit\Framework\TestCase;
 use VCR\Request;
 
-class BeforeHttpRequestEventTest extends \PHPUnit_Framework_TestCase
+class BeforeHttpRequestEventTest extends TestCase
 {
     /**
      * @var BeforeHttpRequestEvent

--- a/tests/VCR/Event/BeforePlaybackEventTest.php
+++ b/tests/VCR/Event/BeforePlaybackEventTest.php
@@ -2,12 +2,13 @@
 
 namespace VCR\Event;
 
+use PHPUnit\Framework\TestCase;
 use VCR\Request;
 use VCR\Cassette;
 use VCR\Configuration;
 use VCR\Storage;
 
-class BeforePlaybackEventTest extends \PHPUnit_Framework_TestCase
+class BeforePlaybackEventTest extends TestCase
 {
     /**
      * @var BeforePlaybackEvent

--- a/tests/VCR/Event/BeforeRecordEventTest.php
+++ b/tests/VCR/Event/BeforeRecordEventTest.php
@@ -2,13 +2,14 @@
 
 namespace VCR\Event;
 
+use PHPUnit\Framework\TestCase;
 use VCR\Request;
 use VCR\Cassette;
 use VCR\Configuration;
 use VCR\Storage;
 use VCR\Response;
 
-class BeforeRecordEventTest extends \PHPUnit_Framework_TestCase
+class BeforeRecordEventTest extends TestCase
 {
     /**
      * @var BeforeRecordEvent

--- a/tests/VCR/LibraryHooks/CurlHookTest.php
+++ b/tests/VCR/LibraryHooks/CurlHookTest.php
@@ -2,6 +2,7 @@
 
 namespace VCR\LibraryHooks;
 
+use PHPUnit\Framework\TestCase;
 use VCR\Request;
 use VCR\Response;
 use VCR\Configuration;
@@ -11,7 +12,7 @@ use VCR\Util\StreamProcessor;
 /**
  * Test if intercepting http/https using curl works.
  */
-class CurlHookTest extends \PHPUnit_Framework_TestCase
+class CurlHookTest extends TestCase
 {
     public $expected = 'example response body';
     /**
@@ -71,10 +72,10 @@ class CurlHookTest extends \PHPUnit_Framework_TestCase
      */
     public function testShouldNotInterceptCallWhenDisabled()
     {
-        $testClass = $this;
+        $intercepted = false;
         $this->curlHook->enable(
-            function () use ($testClass) {
-                $testClass->fail('This request should not have been intercepted.');
+            function () use (&$intercepted) {
+                $intercepted = true;
             }
         );
         $this->curlHook->disable();
@@ -84,6 +85,7 @@ class CurlHookTest extends \PHPUnit_Framework_TestCase
         curl_setopt($curlHandle, CURLOPT_RETURNTRANSFER, true);
         curl_exec($curlHandle);
         curl_close($curlHandle);
+        $this->assertFalse($intercepted, 'This request should not have been intercepted.');
     }
 
     public function testShouldWriteFileOnFileDownload()
@@ -250,12 +252,18 @@ class CurlHookTest extends \PHPUnit_Framework_TestCase
         $this->curlHook->disable();
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testShouldNotThrowErrorWhenDisabledTwice()
     {
         $this->curlHook->disable();
         $this->curlHook->disable();
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testShouldNotThrowErrorWhenEnabledTwice()
     {
         $this->curlHook->enable($this->getTestCallback());
@@ -314,6 +322,9 @@ class CurlHookTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($afterLastInfo, 'Multi info called the last time should return false.');
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testShouldNotInterceptMultiCallWhenDisabled()
     {
         $testClass = $this;

--- a/tests/VCR/LibraryHooks/SoapHookTest.php
+++ b/tests/VCR/LibraryHooks/SoapHookTest.php
@@ -2,6 +2,7 @@
 
 namespace VCR\LibraryHooks;
 
+use PHPUnit\Framework\TestCase;
 use VCR\Request;
 use VCR\Response;
 use VCR\Configuration;
@@ -11,7 +12,7 @@ use VCR\Util\StreamProcessor;
 /**
  * Test if intercepting http/https using soap works.
  */
-class SoapHookTest extends \PHPUnit_Framework_TestCase
+class SoapHookTest extends TestCase
 {
     const WSDL = 'https://raw.githubusercontent.com/php-vcr/php-vcr/master/tests/fixtures/soap/wsdl/weather.wsdl';
 

--- a/tests/VCR/LibraryHooks/StreamWrapperHookTest.php
+++ b/tests/VCR/LibraryHooks/StreamWrapperHookTest.php
@@ -2,13 +2,14 @@
 
 namespace VCR\LibraryHooks;
 
+use PHPUnit\Framework\TestCase;
 use VCR\Request;
 use VCR\Response;
 
 /**
  * Test if intercepting http/https using stream wrapper works.
  */
-class StreamWrapperHookTest extends \PHPUnit_Framework_TestCase
+class StreamWrapperHookTest extends TestCase
 {
     public function testEnable()
     {

--- a/tests/VCR/RequestMatcherTest.php
+++ b/tests/VCR/RequestMatcherTest.php
@@ -2,7 +2,9 @@
 
 namespace VCR;
 
-class RequestMatcherTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class RequestMatcherTest extends TestCase
 {
     public function testMatchingMethod()
     {

--- a/tests/VCR/RequestTest.php
+++ b/tests/VCR/RequestTest.php
@@ -2,10 +2,12 @@
 
 namespace VCR;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Test integration of PHPVCR with PHPUnit.
  */
-class RequestTest extends \PHPUnit_Framework_TestCase
+class RequestTest extends TestCase
 {
     /**
      * @var \VCR\Request
@@ -59,7 +61,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     public function testMatchesThrowsExceptionIfMatcherNotFound()
     {
         $request = new Request('POST', 'http://example.com', array('User-Agent' => 'Unit-Test'));
-        $this->setExpectedException(
+        $this->expectException(
             '\BadFunctionCallException',
             "Matcher could not be executed. Array\n(\n    [0] => some\n    [1] => method\n)\n"
         );

--- a/tests/VCR/ResponseTest.php
+++ b/tests/VCR/ResponseTest.php
@@ -2,10 +2,12 @@
 
 namespace VCR;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Test VCRs response object.
  */
-class ResponseTest extends \PHPUnit_Framework_TestCase
+class ResponseTest extends TestCase
 {
     public function testGetHeaders()
     {

--- a/tests/VCR/Storage/AbstractStorageTest.php
+++ b/tests/VCR/Storage/AbstractStorageTest.php
@@ -3,11 +3,12 @@
 namespace VCR\Storage;
 
 use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test integration of PHPVCR with PHPUnit.
  */
-class AbstractStorageTest extends \PHPUnit_Framework_TestCase
+class AbstractStorageTest extends TestCase
 {
     protected $handle;
     protected $filePath;
@@ -27,7 +28,7 @@ class AbstractStorageTest extends \PHPUnit_Framework_TestCase
 
     public function testRootNotExisting()
     {
-        $this->setExpectedException('\VCR\VCRException', "Cassette path 'vfs://test/foo' is not existing or not a directory");
+        $this->expectException('\VCR\VCRException', "Cassette path 'vfs://test/foo' is not existing or not a directory");
 
         vfsStream::setup('test');
         new TestStorage(vfsStream::url('test/foo'), 'file');

--- a/tests/VCR/Storage/BlackholeTest.php
+++ b/tests/VCR/Storage/BlackholeTest.php
@@ -2,7 +2,9 @@
 
 namespace VCR\Storage;
 
-class BlackholeTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class BlackholeTest extends TestCase
 {
     protected $storage;
 

--- a/tests/VCR/Storage/JsonTest.php
+++ b/tests/VCR/Storage/JsonTest.php
@@ -3,11 +3,12 @@
 namespace VCR\Storage;
 
 use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test integration of PHPVCR with PHPUnit.
  */
-class JsonTest extends \PHPUnit_Framework_TestCase
+class JsonTest extends TestCase
 {
     protected $handle;
     protected $filePath;

--- a/tests/VCR/Storage/YamlTest.php
+++ b/tests/VCR/Storage/YamlTest.php
@@ -3,11 +3,12 @@
 namespace VCR\Storage;
 
 use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test integration of PHPVCR with PHPUnit.
  */
-class YamlTest extends \PHPUnit_Framework_TestCase
+class YamlTest extends TestCase
 {
     public function setUp()
     {

--- a/tests/VCR/Util/CurlHelperTest.php
+++ b/tests/VCR/Util/CurlHelperTest.php
@@ -3,10 +3,11 @@
 namespace VCR\Util;
 
 use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
 use VCR\Request;
 use VCR\Response;
 
-class CurlHelperTest extends \PHPUnit_Framework_TestCase
+class CurlHelperTest extends TestCase
 {
     /**
      * @dataProvider getHttpMethodsProvider()
@@ -160,7 +161,7 @@ class CurlHelperTest extends \PHPUnit_Framework_TestCase
 
     public function testSetCurlOptionReadFunctionMissingSize()
     {
-        $this->setExpectedException('\VCR\VCRException', 'To set a CURLOPT_READFUNCTION, CURLOPT_INFILESIZE must be set.');
+        $this->expectException('\VCR\VCRException', 'To set a CURLOPT_READFUNCTION, CURLOPT_INFILESIZE must be set.');
         $request = new Request('POST', 'example.com');
 
         $callback = function ($curlHandle, $fileHandle, $size) {

--- a/tests/VCR/Util/HttpClientTest.php
+++ b/tests/VCR/Util/HttpClientTest.php
@@ -2,10 +2,11 @@
 
 namespace VCR\Util;
 
+use PHPUnit\Framework\TestCase;
 use VCR\Response;
 use VCR\Request;
 
-class HttpClientTest extends \PHPUnit_Framework_TestCase
+class HttpClientTest extends TestCase
 {
     public function testCreateHttpClient()
     {

--- a/tests/VCR/Util/HttpUtilTest.php
+++ b/tests/VCR/Util/HttpUtilTest.php
@@ -2,7 +2,9 @@
 
 namespace VCR\Util;
 
-class HttpUtilTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class HttpUtilTest extends TestCase
 {
     public function testParseResponseBasic()
     {

--- a/tests/VCR/Util/SoapClientTest.php
+++ b/tests/VCR/Util/SoapClientTest.php
@@ -3,10 +3,12 @@
 namespace VCR\Util;
 
 use lapistano\ProxyObject\ProxyBuilder;
+use PHPUnit\Framework\TestCase;
+use VCR\LibraryHooks\SoapHook;
 use VCR\VCRException;
 use VCR\Util\SoapClient;
 
-class SoapClientTest extends \PHPUnit_Framework_TestCase
+class SoapClientTest extends TestCase
 {
     const WSDL = 'https://raw.githubusercontent.com/php-vcr/php-vcr/master/tests/fixtures/soap/wsdl/weather.wsdl';
     const ACTION = 'http://ws.cdyne.com/WeatherWS/GetCityWeatherByZIP';
@@ -118,26 +120,26 @@ class SoapClientTest extends \PHPUnit_Framework_TestCase
         $client = new SoapClient(self::WSDL);
         $client->setLibraryHook($hook);
 
-        $this->setExpectedException($exception);
+        $this->expectException($exception);
 
         $client->__doRequest('Knorx ist groß', self::WSDL, self::ACTION, SOAP_1_2);
     }
 
     public function testLibraryHook()
     {
-        $client = new SoapClient(self::WSDL);
+        $client = new class(self::WSDL) extends SoapClient {
+            // A proxy to access the protected getLibraryHook method.
+            public function publicGetLibraryHook(): SoapHook
+            {
+                return $this->getLibraryHook();
+            }
+        };
 
-        $proxy = new ProxyBuilder('\VCR\Util\SoapClient');
-        $client = $proxy
-            ->disableOriginalConstructor()
-            ->setMethods(array('getLibraryHook'))
-            ->getProxy();
-
-        $this->assertInstanceOf('\VCR\LibraryHooks\SoapHook', $client->getLibraryHook());
+        $this->assertInstanceOf('\VCR\LibraryHooks\SoapHook', $client->publicGetLibraryHook());
 
         $client->setLibraryHook($this->getLibraryHookMock(true));
 
-        $this->assertInstanceOf('\VCR\LibraryHooks\SoapHook', $client->getLibraryHook());
+        $this->assertInstanceOf('\VCR\LibraryHooks\SoapHook', $client->publicGetLibraryHook());
     }
 
     public function testGetLastWhateverBeforeRequest()

--- a/tests/VCR/Util/StreamHelperTest.php
+++ b/tests/VCR/Util/StreamHelperTest.php
@@ -2,9 +2,10 @@
 
 namespace VCR\Util;
 
+use PHPUnit\Framework\TestCase;
 use VCR\Request;
 
-class StreamHelperTest extends \PHPUnit_Framework_TestCase
+class StreamHelperTest extends TestCase
 {
     public function streamContexts()
     {

--- a/tests/VCR/Util/StreamProcessorTest.php
+++ b/tests/VCR/Util/StreamProcessorTest.php
@@ -2,7 +2,10 @@
 
 namespace VCR\Util;
 
-class StreamProcessorTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Error\Warning;
+
+class StreamProcessorTest extends TestCase
 {
 
     /**
@@ -85,6 +88,9 @@ class StreamProcessorTest extends \PHPUnit_Framework_TestCase
         restore_error_handler();
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testUrlStatSuccessfully()
     {
         $test = $this;
@@ -98,15 +104,16 @@ class StreamProcessorTest extends \PHPUnit_Framework_TestCase
         restore_error_handler();
     }
 
-    /**
-     * @expectedException PHPUnit_Framework_Error_Warning
-     */
     public function testUrlStatFileNotFound()
     {
         $processor = new StreamProcessor();
+        $this->expectException(Warning::class);
         $processor->url_stat('file_not_found', 0);
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testQuietUrlStatFileNotFoundToBeQuiet()
     {
         $processor = new StreamProcessor();

--- a/tests/VCR/Util/TextUtilTest.php
+++ b/tests/VCR/Util/TextUtilTest.php
@@ -2,10 +2,12 @@
 
 namespace VCR\Util;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests TextUtil methods.
  */
-class TextUtilTest extends \PHPUnit_Framework_TestCase
+class TextUtilTest extends TestCase
 {
     /**
      * @dataProvider curlMethodsProvider

--- a/tests/VCR/VCRFactoryTest.php
+++ b/tests/VCR/VCRFactoryTest.php
@@ -3,11 +3,12 @@
 namespace VCR;
 
 use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test instance creation.
  */
-class VCRFactoryTest extends \PHPUnit_Framework_TestCase
+class VCRFactoryTest extends TestCase
 {
     /**
      * @dataProvider instanceProvider

--- a/tests/VCR/VCRTest.php
+++ b/tests/VCR/VCRTest.php
@@ -2,13 +2,14 @@
 
 namespace VCR;
 
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\Event;
 use org\bovigo\vfs\vfsStream;
 
 /**
  * Test integration of PHPVCR with PHPUnit.
  */
-class VCRTest extends \PHPUnit_Framework_TestCase
+class VCRTest extends TestCase
 {
     public static function setupBeforeClass()
     {
@@ -18,7 +19,7 @@ class VCRTest extends \PHPUnit_Framework_TestCase
     public function testUseStaticCallsNotInitialized()
     {
         VCR::configure()->enableLibraryHooks(array('stream_wrapper'));
-        $this->setExpectedException(
+        $this->expectException(
             'VCR\VCRException',
             'Please turn on VCR before inserting a cassette, use: VCR::turnOn()'
         );
@@ -76,6 +77,9 @@ class VCRTest extends \PHPUnit_Framework_TestCase
         VCR::turnOff();
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testShouldNotInterceptCallsToDevUrandom()
     {
         if ('\\' === DIRECTORY_SEPARATOR) {
@@ -96,7 +100,7 @@ class VCRTest extends \PHPUnit_Framework_TestCase
 
     public function testShouldThrowExceptionIfNoCassettePresent()
     {
-        $this->setExpectedException(
+        $this->expectException(
             'BadMethodCallException',
             'Invalid http request. No cassette inserted. Please make sure to insert '
             . "a cassette in your unit test using VCR::insertCassette('name');"
@@ -109,7 +113,8 @@ class VCRTest extends \PHPUnit_Framework_TestCase
         VCR::turnOff();
     }
 
-    public function testInsertMultipleCassettes()
+    // Useless test: already tested in VideorecorderTest::testInsertCassetteEjectExisting
+    /*public function testInsertMultipleCassettes()
     {
         $this->configureVirtualCassette();
 
@@ -117,14 +122,14 @@ class VCRTest extends \PHPUnit_Framework_TestCase
         VCR::insertCassette('unittest_cassette1');
         VCR::insertCassette('unittest_cassette2');
         // TODO: Check of cassette was changed
-    }
+    }*/
 
     public function testDoesNotBlockThrowingExceptions()
     {
         $this->configureVirtualCassette();
 
         VCR::turnOn();
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
         VCR::insertCassette('unittest_cassette1');
         throw new \InvalidArgumentException('test');
     }

--- a/tests/VCR/VideorecorderTest.php
+++ b/tests/VCR/VideorecorderTest.php
@@ -4,11 +4,12 @@ namespace VCR;
 
 use lapistano\ProxyObject\ProxyBuilder;
 use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test Videorecorder.
  */
-class VideorecorderTest extends \PHPUnit_Framework_TestCase
+class VideorecorderTest extends TestCase
 {
     public function testCreateVideorecorder()
     {
@@ -47,20 +48,21 @@ class VideorecorderTest extends \PHPUnit_Framework_TestCase
         $configuration->enableLibraryHooks(array());
         $configuration->setMode('new_episodes');
 
-        $proxy = new ProxyBuilder('\VCR\Videorecorder');
-        $videorecorder = $proxy
-            ->setConstructorArgs(array($configuration, $client, VCRFactory::getInstance()))
-            ->setProperties(array('cassette', 'client'))
-            ->getProxy();
-        $videorecorder->client = $client;
-        $videorecorder->cassette = $this->getCassetteMock($request, $response);
+        $videorecorder = new class($configuration, $client, VCRFactory::getInstance()) extends Videorecorder {
+            public function setCassette(Cassette $cassette): void
+            {
+                $this->cassette = $cassette;
+            }
+        };
+
+        $videorecorder->setCassette($this->getCassetteMock($request, $response));
 
         $this->assertEquals($response, $videorecorder->handleRequest($request));
     }
 
     public function testHandleRequestThrowsExceptionWhenModeIsNone()
     {
-        $this->setExpectedException(
+        $this->expectException(
             'LogicException',
             "The request does not match a previously recorded request and the 'mode' is set to 'none'. "
             . "If you want to send the request anyway, make sure your 'mode' is set to 'new_episodes'."
@@ -73,14 +75,14 @@ class VideorecorderTest extends \PHPUnit_Framework_TestCase
         $configuration->enableLibraryHooks(array());
         $configuration->setMode('none');
 
-        $proxy = new ProxyBuilder('\VCR\Videorecorder');
-        $videorecorder = $proxy
-            ->setConstructorArgs(array($configuration, $client, VCRFactory::getInstance()))
-            ->setProperties(array('cassette', 'client'))
-            ->getProxy();
-        $videorecorder->client = $client;
+        $videorecorder = new class($configuration, $client, VCRFactory::getInstance()) extends Videorecorder {
+            public function setCassette(Cassette $cassette): void
+            {
+                $this->cassette = $cassette;
+            }
+        };
 
-        $videorecorder->cassette = $this->getCassetteMock($request, $response, 'none');
+        $videorecorder->setCassette($this->getCassetteMock($request, $response, 'none'));
 
         $videorecorder->handleRequest($request);
     }
@@ -94,21 +96,21 @@ class VideorecorderTest extends \PHPUnit_Framework_TestCase
         $configuration->enableLibraryHooks(array());
         $configuration->setMode('once');
 
-        $proxy = new ProxyBuilder('\VCR\Videorecorder');
-        $videorecorder = $proxy
-            ->setConstructorArgs(array($configuration, $client, VCRFactory::getInstance()))
-            ->setProperties(array('cassette', 'client'))
-            ->getProxy();
-        $videorecorder->client = $client;
+        $videorecorder = new class($configuration, $client, VCRFactory::getInstance()) extends Videorecorder {
+            public function setCassette(Cassette $cassette): void
+            {
+                $this->cassette = $cassette;
+            }
+        };
 
-        $videorecorder->cassette = $this->getCassetteMock($request, $response, 'once', true);
+        $videorecorder->setCassette($this->getCassetteMock($request, $response, 'once', true));
 
         $this->assertEquals($response, $videorecorder->handleRequest($request));
     }
 
     public function testHandleRequestThrowsExceptionWhenModeIsOnceAndCassetteIsOld()
     {
-        $this->setExpectedException(
+        $this->expectException(
             'LogicException',
             "The request does not match a previously recorded request and the 'mode' is set to 'once'. "
             . "If you want to send the request anyway, make sure your 'mode' is set to 'new_episodes'."
@@ -121,14 +123,14 @@ class VideorecorderTest extends \PHPUnit_Framework_TestCase
         $configuration->enableLibraryHooks(array());
         $configuration->setMode('once');
 
-        $proxy = new ProxyBuilder('\VCR\Videorecorder');
-        $videorecorder = $proxy
-            ->setConstructorArgs(array($configuration, $client, VCRFactory::getInstance()))
-            ->setProperties(array('cassette', 'client'))
-            ->getProxy();
-        $videorecorder->client = $client;
+        $videorecorder = new class($configuration, $client, VCRFactory::getInstance()) extends Videorecorder {
+            public function setCassette(Cassette $cassette): void
+            {
+                $this->cassette = $cassette;
+            }
+        };
 
-        $videorecorder->cassette = $this->getCassetteMock($request, $response, 'once', false);
+        $videorecorder->setCassette($this->getCassetteMock($request, $response, 'once', false));
 
         $videorecorder->handleRequest($request);
     }

--- a/tests/integration/guzzle/3/composer.lock
+++ b/tests/integration/guzzle/3/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "68366044f967cdb769d600d4f2977188",
+    "content-hash": "8573d0718749797c92bc6d384e04eaff",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -96,32 +96,34 @@
                 "rest",
                 "web service"
             ],
-            "time": "2014-01-28 22:29:15"
+            "time": "2014-01-28T22:29:15+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v2.6.1",
-            "target-dir": "Symfony/Component/EventDispatcher",
+            "version": "v4.1.6",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/EventDispatcher.git",
-                "reference": "720fe9bca893df7ad1b4546649473b5afddf0216"
+                "url": "https://github.com/symfony/event-dispatcher.git",
+                "reference": "bfb30c2ad377615a463ebbc875eba64a99f6aa3e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/EventDispatcher/zipball/720fe9bca893df7ad1b4546649473b5afddf0216",
-                "reference": "720fe9bca893df7ad1b4546649473b5afddf0216",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/bfb30c2ad377615a463ebbc875eba64a99f6aa3e",
+                "reference": "bfb30c2ad377615a463ebbc875eba64a99f6aa3e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.1.3"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<3.4"
             },
             "require-dev": {
                 "psr/log": "~1.0",
-                "symfony/config": "~2.0",
-                "symfony/dependency-injection": "~2.6",
-                "symfony/expression-language": "~2.6",
-                "symfony/stopwatch": "~2.2"
+                "symfony/config": "~3.4|~4.0",
+                "symfony/dependency-injection": "~3.4|~4.0",
+                "symfony/expression-language": "~3.4|~4.0",
+                "symfony/stopwatch": "~3.4|~4.0"
             },
             "suggest": {
                 "symfony/dependency-injection": "",
@@ -130,13 +132,16 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.6-dev"
+                    "dev-master": "4.1-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
+                "psr-4": {
                     "Symfony\\Component\\EventDispatcher\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -144,17 +149,17 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
-                },
-                {
                     "name": "Fabien Potencier",
                     "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony EventDispatcher Component",
-            "homepage": "http://symfony.com",
-            "time": "2014-12-02 20:19:20"
+            "homepage": "https://symfony.com",
+            "time": "2018-07-26T09:10:45+00:00"
         }
     ],
     "packages-dev": [],

--- a/tests/integration/guzzle/3/phpunit.xml
+++ b/tests/integration/guzzle/3/phpunit.xml
@@ -6,7 +6,7 @@
 >
 
     <testsuites>
-        <testsuite>
+        <testsuite name="Guzzle 3 test suite">
             <directory>../test</directory>
         </testsuite>
     </testsuites>

--- a/tests/integration/guzzle/4/composer.lock
+++ b/tests/integration/guzzle/4/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "e500b5a216f42ba9ab567e0e9034749f",
+    "content-hash": "dd5aa4e5d110b03429e712f90ca10a0b",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
-            "version": "4.2.3",
+            "version": "4.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "66fd916e9f9130bc22c51450476823391cb2f67c"
+                "reference": "13a8e5acff26b0a87d353042170b48976da004a1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/66fd916e9f9130bc22c51450476823391cb2f67c",
-                "reference": "66fd916e9f9130bc22c51450476823391cb2f67c",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/13a8e5acff26b0a87d353042170b48976da004a1",
+                "reference": "13a8e5acff26b0a87d353042170b48976da004a1",
                 "shasum": ""
             },
             "require": {
@@ -69,7 +69,7 @@
                 "rest",
                 "web service"
             ],
-            "time": "2014-10-05 19:29:14"
+            "time": "2016-07-15T17:44:18+00:00"
         },
         {
             "name": "guzzlehttp/streams",
@@ -122,7 +122,7 @@
                 "Guzzle",
                 "stream"
             ],
-            "time": "2014-08-17 21:15:53"
+            "time": "2014-08-17T21:15:53+00:00"
         }
     ],
     "packages-dev": [],

--- a/tests/integration/guzzle/5/composer.lock
+++ b/tests/integration/guzzle/5/composer.lock
@@ -1,40 +1,35 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "3dc2ee230cecf4c3dd15b49672e806db",
+    "content-hash": "a426abfa60297f7ecc0e43c351699bf4",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
-            "version": "5.1.0",
+            "version": "5.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "f1085bb4e023766a66b7b051914ec73bdf7202b5"
+                "reference": "93bbdb30d59be6cd9839495306c65f2907370eb9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/f1085bb4e023766a66b7b051914ec73bdf7202b5",
-                "reference": "f1085bb4e023766a66b7b051914ec73bdf7202b5",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/93bbdb30d59be6cd9839495306c65f2907370eb9",
+                "reference": "93bbdb30d59be6cd9839495306c65f2907370eb9",
                 "shasum": ""
             },
             "require": {
-                "guzzlehttp/ringphp": "~1.0",
-                "php": ">=5.4.0"
+                "guzzlehttp/ringphp": "^1.1",
+                "php": ">=5.4.0",
+                "react/promise": "^2.2"
             },
             "require-dev": {
                 "ext-curl": "*",
-                "phpunit/phpunit": "~4.0",
-                "psr/log": "~1.0"
+                "phpunit/phpunit": "^4.0"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.0-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "GuzzleHttp\\": "src/"
@@ -62,20 +57,20 @@
                 "rest",
                 "web service"
             ],
-            "time": "2014-12-19 20:27:15"
+            "time": "2018-07-31T13:33:10+00:00"
         },
         {
             "name": "guzzlehttp/ringphp",
-            "version": "1.0.5",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/RingPHP.git",
-                "reference": "a903f51b692427318bc813217c0e6505287e79a4"
+                "reference": "5e2a174052995663dd68e6b5ad838afd47dd615b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/RingPHP/zipball/a903f51b692427318bc813217c0e6505287e79a4",
-                "reference": "a903f51b692427318bc813217c0e6505287e79a4",
+                "url": "https://api.github.com/repos/guzzle/RingPHP/zipball/5e2a174052995663dd68e6b5ad838afd47dd615b",
+                "reference": "5e2a174052995663dd68e6b5ad838afd47dd615b",
                 "shasum": ""
             },
             "require": {
@@ -93,7 +88,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "1.1-dev"
                 }
             },
             "autoload": {
@@ -112,7 +107,8 @@
                     "homepage": "https://github.com/mtdowling"
                 }
             ],
-            "time": "2014-12-11 05:50:32"
+            "description": "Provides a simple API and specification that abstracts away the details of HTTP into a single PHP function.",
+            "time": "2018-07-31T13:22:33+00:00"
         },
         {
             "name": "guzzlehttp/streams",
@@ -162,31 +158,29 @@
                 "Guzzle",
                 "stream"
             ],
-            "time": "2014-10-12 19:18:40"
+            "time": "2014-10-12T19:18:40+00:00"
         },
         {
             "name": "react/promise",
-            "version": "v2.2.0",
+            "version": "v2.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/reactphp/promise.git",
-                "reference": "365fcee430dfa4ace1fbc75737ca60ceea7eeeef"
+                "reference": "f4edc2581617431aea50430749db55cc3fc031b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/promise/zipball/365fcee430dfa4ace1fbc75737ca60ceea7eeeef",
-                "reference": "365fcee430dfa4ace1fbc75737ca60ceea7eeeef",
+                "url": "https://api.github.com/repos/reactphp/promise/zipball/f4edc2581617431aea50430749db55cc3fc031b3",
+                "reference": "f4edc2581617431aea50430749db55cc3fc031b3",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4.0"
             },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
+            "require-dev": {
+                "phpunit/phpunit": "~4.8"
             },
+            "type": "library",
             "autoload": {
                 "psr-4": {
                     "React\\Promise\\": "src/"
@@ -202,11 +196,15 @@
             "authors": [
                 {
                     "name": "Jan Sorgalla",
-                    "email": "jsorgalla@googlemail.com"
+                    "email": "jsorgalla@gmail.com"
                 }
             ],
             "description": "A lightweight implementation of CommonJS Promises/A for PHP",
-            "time": "2014-12-30 13:32:42"
+            "keywords": [
+                "promise",
+                "promises"
+            ],
+            "time": "2018-06-13T15:59:06+00:00"
         }
     ],
     "packages-dev": [],

--- a/tests/integration/guzzle/5/phpunit.xml
+++ b/tests/integration/guzzle/5/phpunit.xml
@@ -6,7 +6,7 @@
 >
 
     <testsuites>
-        <testsuite>
+        <testsuite name="Guzzle 5 test suite">
             <directory>../test</directory>
         </testsuite>
     </testsuites>

--- a/tests/integration/guzzle/6/phpunit.xml
+++ b/tests/integration/guzzle/6/phpunit.xml
@@ -6,7 +6,7 @@
 >
 
     <testsuites>
-        <testsuite>
+        <testsuite name="Guzzle 6 test suite">
             <directory>../test</directory>
             <directory>test</directory>
         </testsuite>

--- a/tests/integration/guzzle/6/test/AsyncTest.php
+++ b/tests/integration/guzzle/6/test/AsyncTest.php
@@ -4,11 +4,12 @@ namespace VCR\Example;
 
 use GuzzleHttp\Client;
 use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests example request.
  */
-class AsyncTest extends \PHPUnit_Framework_TestCase
+class AsyncTest extends TestCase
 {
     const TEST_GET_URL = 'https://api.chew.pro/trbmb';
     const TEST_GET_URL_2 = 'https://api.chew.pro/trbmb?foo=42';

--- a/tests/integration/guzzle/test/VCR/Example/ExampleHttpClientTest.php
+++ b/tests/integration/guzzle/test/VCR/Example/ExampleHttpClientTest.php
@@ -3,11 +3,12 @@
 namespace VCR\Example;
 
 use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests example request.
  */
-class ExampleHttpClientTest extends \PHPUnit_Framework_TestCase
+class ExampleHttpClientTest extends TestCase
 {
     const TEST_GET_URL = 'https://api.chew.pro/trbmb';
     const TEST_POST_URL = 'https://httpbin.org/post';

--- a/tests/integration/soap/phpunit.xml
+++ b/tests/integration/soap/phpunit.xml
@@ -6,7 +6,7 @@
 >
 
     <testsuites>
-        <testsuite>
+        <testsuite name="Soap test suite">
             <directory>./test</directory>
         </testsuite>
     </testsuites>

--- a/tests/integration/soap/test/VCR/Example/ExampleSoapClientTest.php
+++ b/tests/integration/soap/test/VCR/Example/ExampleSoapClientTest.php
@@ -3,13 +3,14 @@
 namespace VCR\Example;
 
 use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Converts temperature units from webservicex
  *
  * @link http://www.webservicex.net/New/Home/ServiceDetail/31
  */
-class ExampleSoapClientTest extends \PHPUnit_Framework_TestCase
+class ExampleSoapClientTest extends TestCase
 {
     public function setUp()
     {


### PR DESCRIPTION
### Context

Upgrading all the code to PHPUnit 7.

### What has been done

Upgraded to PHPunit 7.
Removed the lapistano/proxy-object library. It was used to access protected properties of objects and was abandonned (project did not move in 3 years), and incompatible with PHPUnit 7.
I replaced it with simple anonymous classes that extend the object that was previously proxied and that have an extra public getter on the protected properties/methods I want to access.
So I replaced a complete library with a simple new language feature added in PHP 7 (anonymous classes). PHP7 FTW!
