### PR TITLE
Added SoapOperation request matcher + unit tests

### DIFF
--- a/src/VCR/Configuration.php
+++ b/src/VCR/Configuration.php
@@ -89,13 +89,14 @@ class Configuration
      * @var array<string,callable(Request $first, Request $second):bool> List of RequestMatcher names and callbacks.
      */
     private $availableRequestMatchers = array(
-        'method'       => array('VCR\RequestMatcher', 'matchMethod'),
-        'url'          => array('VCR\RequestMatcher', 'matchUrl'),
-        'host'         => array('VCR\RequestMatcher', 'matchHost'),
-        'headers'      => array('VCR\RequestMatcher', 'matchHeaders'),
-        'body'         => array('VCR\RequestMatcher', 'matchBody'),
-        'post_fields'  => array('VCR\RequestMatcher', 'matchPostFields'),
-        'query_string' => array('VCR\RequestMatcher', 'matchQueryString'),
+        'method'         => array(RequestMatcher::class, 'matchMethod'),
+        'url'            => array(RequestMatcher::class, 'matchUrl'),
+        'host'           => array(RequestMatcher::class, 'matchHost'),
+        'headers'        => array(RequestMatcher::class, 'matchHeaders'),
+        'body'           => array(RequestMatcher::class, 'matchBody'),
+        'post_fields'    => array(RequestMatcher::class, 'matchPostFields'),
+        'query_string'   => array(RequestMatcher::class, 'matchQueryString'),
+        'soap_operation' => array(RequestMatcher::class, 'matchSoapOperation'),
     );
 
     /**

--- a/src/VCR/RequestMatcher.php
+++ b/src/VCR/RequestMatcher.php
@@ -10,93 +10,119 @@ class RequestMatcher
     /**
      * Returns true if the method of both specified requests match.
      *
-     * @param  Request $first  First request to match.
-     * @param  Request $second Second request to match.
+     * @param  Request $storedRequest First request to match, coming from the cassette.
+     * @param  Request $request Second request to match, the request performed by the user.
      *
      * @return boolean True if the method of both specified requests match.
      */
-    public static function matchMethod(Request $first, Request $second): bool
+    public static function matchMethod(Request $storedRequest, Request $request): bool
     {
-        return $first->getMethod() == $second->getMethod();
+        return $storedRequest->getMethod() == $request->getMethod();
     }
 
     /**
      * Returns true if the url of both specified requests match.
      *
-     * @param  Request $first  First request to match.
-     * @param  Request $second Second request to match.
+     * @param  Request $storedRequest First request to match, coming from the cassette.
+     * @param  Request $request Second request to match, the request performed by the user.
      *
      * @return boolean True if the url of both specified requests match.
      */
-    public static function matchUrl(Request $first, Request $second): bool
+    public static function matchUrl(Request $storedRequest, Request $request): bool
     {
-        return $first->getPath() === $second->getPath();
+        return $storedRequest->getPath() === $request->getPath();
     }
 
     /**
      * Returns true if the host of both specified requests match.
      *
-     * @param  Request $first  First request to match.
-     * @param  Request $second Second request to match.
+     * @param  Request $storedRequest First request to match, coming from the cassette.
+     * @param  Request $request Second request to match, the request performed by the user.
      *
      * @return boolean True if the host of both specified requests match.
      */
-    public static function matchHost(Request $first, Request $second): bool
+    public static function matchHost(Request $storedRequest, Request $request): bool
     {
-        return $first->getHost() === $second->getHost();
+        return $storedRequest->getHost() === $request->getHost();
     }
 
     /**
      * Returns true if the headers of both specified requests match.
      *
-     * @param  Request $first  First request to match.
-     * @param  Request $second Second request to match.
+     * @param  Request $storedRequest First request to match, coming from the cassette.
+     * @param  Request $request Second request to match, the request performed by the user.
      *
      * @return boolean True if the headers of both specified requests match.
      */
-    public static function matchHeaders(Request $first, Request $second): bool
+    public static function matchHeaders(Request $storedRequest, Request $request): bool
     {
         // Use array_filter to ignore headers which are null.
 
-        return array_filter($first->getHeaders()) === array_filter($second->getHeaders());
+        return array_filter($storedRequest->getHeaders()) === array_filter($request->getHeaders());
     }
 
     /**
      * Returns true if the body of both specified requests match.
      *
-     * @param  Request $first  First request to match.
-     * @param  Request $second Second request to match.
+     * @param  Request $storedRequest First request to match, coming from the cassette.
+     * @param  Request $request Second request to match, the request performed by the user.
      *
      * @return boolean True if the body of both specified requests match.
      */
-    public static function matchBody(Request $first, Request $second): bool
+    public static function matchBody(Request $storedRequest, Request $request): bool
     {
-        return $first->getBody() === $second->getBody();
+        return $storedRequest->getBody() === $request->getBody();
     }
 
     /**
      * Returns true if the post fields of both specified requests match.
      *
-     * @param  Request $first  First request to match.
-     * @param  Request $second Second request to match.
+     * @param  Request $storedRequest First request to match, coming from the cassette.
+     * @param  Request $request Second request to match, the request performed by the user.
      *
      * @return boolean True if the post fields of both specified requests match.
      */
-    public static function matchPostFields(Request $first, Request $second): bool
+    public static function matchPostFields(Request $storedRequest, Request $request): bool
     {
-        return $first->getPostFields() === $second->getPostFields();
+        return $storedRequest->getPostFields() === $request->getPostFields();
     }
 
     /**
      * Returns true if the query string of both specified requests match.
      *
-     * @param  Request $first  First request to match.
-     * @param  Request $second Second request to match.
+     * @param  Request $storedRequest First request to match, coming from the cassette.
+     * @param  Request $request Second request to match, the request performed by the user.
      *
      * @return boolean True if the query string of both specified requests match.
      */
-    public static function matchQueryString(Request $first, Request $second): bool
+    public static function matchQueryString(Request $storedRequest, Request $request): bool
     {
-        return $first->getQuery() === $second->getQuery();
+        return $storedRequest->getQuery() === $request->getQuery();
+    }
+
+    /**
+     * Returns true if the SOAP operation of both specified requests match, or if the request is not a SOAP request.
+     *
+     * @param  Request $storedRequest First request to match, coming from the cassette.
+     * @param  Request $request Second request to match, the request performed by the user.
+     *
+     * @return boolean True if the query string of both specified requests match.
+     */
+    public static function matchSoapOperation(Request $storedRequest, Request $request): bool
+    {
+        $soapOperationRequest = preg_match('/<SOAP-ENV:Body><(.*?)>/m', $request->getBody(), $matches);
+        if (empty($matches)) {
+            // The request is not a SOAP request
+            return true;
+        }
+        $operationRequest = $matches[1];
+        $soapOperationStoredRequest = preg_match('/<SOAP-ENV:Body><(.*?)>/m', $storedRequest->getBody(), $matches);
+        if (empty($matches)) {
+            // The stored request is not a SOAP request
+            return false;
+        }
+        $operationStoredRequest = $matches[1];
+
+        return $operationRequest === $operationStoredRequest;
     }
 }

--- a/tests/VCR/RequestMatcherTest.php
+++ b/tests/VCR/RequestMatcherTest.php
@@ -136,4 +136,38 @@ class RequestMatcherTest extends TestCase
 
         $this->assertFalse(RequestMatcher::matchBody($first, $second), 'Bodies are different.');
     }
+
+    public function testMatchingSoapOperation()
+    {
+        $storedRequest = Request::fromArray([
+            'method' => 'POST',
+            'url' => 'http://example.com',
+            'headers' => array(),
+            'body' => "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:ns1=\"http://tempuri.org\"><SOAP-ENV:Body><ns1:SearchAdresse><myPtr><cp>45000</cp></myPtr></ns1:SearchAdresse></SOAP-ENV:Body></SOAP-ENV:Envelope>\n"
+        ]);
+
+        $request = Request::fromArray([
+            'method' => 'POST',
+            'url' => 'http://example.com',
+            'headers' => array(),
+            'body' => "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:ns1=\"http://tempuri.org\"><SOAP-ENV:Body><ns1:SearchAdresse><myPtr><cp>75008</cp></myPtr></ns1:SearchAdresse></SOAP-ENV:Body></SOAP-ENV:Envelope>\n"
+        ]);
+        $this->assertTrue(RequestMatcher::matchSoapOperation($storedRequest, $request), 'Operations are the same');
+
+        $request = Request::fromArray([
+            'method' => 'POST',
+            'url' => 'http://example.com',
+            'headers' => array(),
+            'body' => "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:ns1=\"http://tempuri.org\"><SOAP-ENV:Body><ns1:SearchFoo><myPtr><cp>75008</cp></myPtr></ns1:SearchFoo></SOAP-ENV:Body></SOAP-ENV:Envelope>\n"
+        ]);
+        $this->assertFalse(RequestMatcher::matchSoapOperation($storedRequest, $request), 'Operations are different');
+
+        $request = Request::fromArray([
+            'method' => 'POST',
+            'url' => 'http://example.com',
+            'headers' => array(),
+            'body' => "{}"
+        ]);
+        $this->assertTrue(RequestMatcher::matchSoapOperation($storedRequest, $request), 'Operation is not SOAP message');
+    }
 }

--- a/tests/VCR/RequestMatcherTest.php
+++ b/tests/VCR/RequestMatcherTest.php
@@ -166,7 +166,7 @@ class RequestMatcherTest extends TestCase
             'method' => 'POST',
             'url' => 'http://example.com',
             'headers' => array(),
-            'body' => "{}"
+            'body' => '{}'
         ]);
         $this->assertTrue(RequestMatcher::matchSoapOperation($storedRequest, $request), 'Operation is not SOAP message');
     }


### PR DESCRIPTION
### Context

Different soap web services can have the same URL if they are hosted on the same server. This poses a problem when using cassettes for several WS operations on the same endpoint.
Either we enable the "body" RequestMatcher and we must send exactly the same request each time.
Or we disable the "body" RequestMatcher but any operation will return the same XML which is obviously not what we want.
There is currently no way to get a XML response that is specific to an "operation" but that does not depends on the parameters passed.

### What has been done

To fix that we created a new 'SOAP operation' request matcher which is based on an xml tag contained in the body of the Soap response.